### PR TITLE
fix(seeding-calc): sync Step 1 with cell-count (3 gaps)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Notion-inspired aesthetic driven by CSS custom properties. Key conventions:
 ## Counting Mode Formulas
 
 ```
-Final Density (cells/mL) = avg_count × multiplier × DF × 10⁴
+Final Concentration (cells/mL) = avg_count × multiplier × DF × 10⁴
 ```
 
 | Mode | Multiplier |

--- a/assets/js/labtools-calc.js
+++ b/assets/js/labtools-calc.js
@@ -190,7 +190,7 @@ function restrictToNumeric(e) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Convert a hemocytometer average count into Final Density (cells/mL).
+ * Convert a hemocytometer average count into Final Concentration (cells/mL).
  *
  * Formula: avgCount × multiplier × dilutionFactor × 10⁴
  *
@@ -215,7 +215,7 @@ function calcCellDensity(avgCount, multiplier, df) {
 /**
  * Calculate total cells in a resuspension volume.
  *
- * @param {number} density   Final Density in cells/mL
+ * @param {number} density   Final Concentration in cells/mL
  * @param {number} volumeML  Resuspension volume in mL (> 0)
  * @returns {number} Rounded total cell count, or NaN if inputs are invalid
  *

--- a/tools/cell-count/README.md
+++ b/tools/cell-count/README.md
@@ -9,7 +9,7 @@ Part of the [LabTools](../../) collection.
 
 Enter your raw cell counts from the hemocytometer and the tool calculates:
 
-- **Final Density** — concentration of cells in your stock suspension (cells/mL)
+- **Final Concentration** — concentration of cells in your stock suspension (cells/mL)
 - **Total Live Cells** — total cells in your tube (requires resuspension volume)
 - **Viability %** — live cell fraction via Trypan Blue exclusion (optional)
 
@@ -50,9 +50,9 @@ The volume of media your cell pellet was resuspended in — i.e., the total volu
 ## Formulas
 
 ```
-Final Density (cells/mL) = avg_count × multiplier × DF × 10⁴
+Final Concentration (cells/mL) = avg_count × multiplier × DF × 10⁴
 
-Total Live Cells = Final Density × Resuspension Volume (mL)
+Total Live Cells = Final Concentration × Resuspension Volume (mL)
 ```
 
 Where `multiplier` depends on counting mode:

--- a/tools/cell-count/index.html
+++ b/tools/cell-count/index.html
@@ -120,14 +120,14 @@
       <div class="r-unit"  id="res-via-note">from dead counts</div>
     </div>
     <div class="result-box hl-blue">
-      <div class="r-label">Final Density</div>
+      <div class="r-label">Final Concentration</div>
       <div class="r-value" id="res-density">—</div>
-      <div class="r-unit"  id="res-density-note">cells / mL</div>
+      <div class="r-unit"  id="res-density-note">cells/mL</div>
     </div>
     <div class="result-box hl-blue">
       <div class="r-label" id="res-total-label">Total Live Cells</div>
       <div class="r-value" id="res-total">—</div>
-      <div class="r-unit"  id="res-total-note">density × vol</div>
+      <div class="r-unit"  id="res-total-note">conc. × vol</div>
     </div>
   </div>
   <div class="unit-legend">K = 1,000 &nbsp;·&nbsp; M = 1,000,000 &nbsp;·&nbsp; B = 1,000,000,000</div>
@@ -255,16 +255,15 @@ function calculate() {
   document.getElementById('res-total-label').textContent =
     isAll ? 'Total Cells' : 'Total Live Cells';
 
-  // ── Final Density ──
+  // ── Final Concentration ──
   document.getElementById('res-density').textContent      = fmt(finalDensity);
-  document.getElementById('res-density-note').textContent =
-    !isNaN(avgLive) ? mode.formulaNote : 'cells / mL';
+  document.getElementById('res-density-note').textContent = 'cells/mL';
 
   // ── Total cells in tube ──
   document.getElementById('res-total').textContent      = fmt(totalCells);
   document.getElementById('res-total-note').textContent =
     !isNaN(finalDensity) && !isNaN(vol) && vol > 0
-      ? 'density × ' + vol + ' mL'
+      ? 'conc. × ' + vol + ' mL'
       : !isNaN(finalDensity) ? 'enter resuspension vol' : '—';
 }
 
@@ -315,7 +314,7 @@ function getExportRows() {
     ['Resuspension volume (mL)',    document.getElementById('vol').value  || ''],
     ['Average live count',          document.getElementById('res-avg').textContent],
     ['Viability',                   document.getElementById('res-via').textContent],
-    ['Final density (cells/mL)',    document.getElementById('res-density').textContent],
+    ['Final concentration (cells/mL)', document.getElementById('res-density').textContent],
     ['Total cells',                 document.getElementById('res-total').textContent],
   ];
 }

--- a/tools/seeding-calc/README.md
+++ b/tools/seeding-calc/README.md
@@ -7,13 +7,13 @@ A guided two-step tool for counting cells and calculating the dilution needed to
 ## Workflow
 
 ### Step 1 — Cell Count
-Identical to the standalone Cell Count Calculator. Count your cells on the hemocytometer to obtain the **Final Density** (cells/mL) of your stock suspension.
+Identical to the standalone Cell Count Calculator. Count your cells on the hemocytometer to obtain the **Final Concentration** (cells/mL) of your stock suspension.
 
 - Select counting mode (all 25 small squares → single corner)
 - Enter Count 1, and optionally Count 2 (second chamber load)
 - Enter Dilution Factor and Resuspension Volume
 - Optionally enter dead cell counts for Trypan Blue viability
-- Click **Next: Dilution →** once a Final Density is calculated
+- Click **Next: Dilution →** once a Final Concentration is calculated
 
 ### Step 2 — Dilution (C₁V₁ = C₂V₂)
 C₁ is automatically carried over from Step 1. Provide any two of the remaining three values and the fourth is solved instantly.
@@ -31,7 +31,7 @@ The solved variable is highlighted in green. When solving for V₁ or V₂, a su
 
 ## Navigation
 
-- **Next: Dilution →** — enabled only when Step 1 has a valid Final Density. Carries C₁ to Step 2.
+- **Next: Dilution →** — enabled only when Step 1 has a valid Final Concentration. Carries C₁ to Step 2.
 - **← Back** — returns to Step 1 with all values preserved.
 - **↺ Reset dilution** — clears C₂, V₁, V₂ while keeping the C₁ prefill from Step 1.
 

--- a/tools/seeding-calc/index.html
+++ b/tools/seeding-calc/index.html
@@ -350,6 +350,7 @@
         <div class="r-unit"  id="res-total-note">conc. × vol</div>
       </div>
     </div>
+    <div class="unit-legend">K = 1,000 &nbsp;·&nbsp; M = 1,000,000 &nbsp;·&nbsp; B = 1,000,000,000</div>
 
     <!-- Export + Nav row -->
     <div class="action-row">
@@ -531,6 +532,7 @@ let step1TotalVolML   = NaN; // resuspension volume from Step 1, in mL
 // ─────────────────────────────────────────────────────────────
 function buildModeSelector() {
   const container = document.getElementById('mode-selector');
+  container.innerHTML = '';
   MODES.forEach(m => {
     const div = document.createElement('div');
     div.className = 'mode-option' + (m.id === currentModeId ? ' active' : '');
@@ -735,7 +737,7 @@ function calcStep1() {
   if (isAll) {
     document.getElementById('res-via').textContent      = 'N/A';
     document.getElementById('res-via-note').textContent = 'count-all mode';
-    document.getElementById('via-note').textContent     = 'Dead cell counting disabled.';
+    document.getElementById('via-note').textContent     = 'Dead cell counting disabled — all cells counted as live.';
     document.getElementById('via-note').className       = 'via-note';
   } else if (!isNaN(viability)) {
     document.getElementById('res-via').textContent      = viability.toFixed(1) + '%';

--- a/tools/seeding-calc/index.html
+++ b/tools/seeding-calc/index.html
@@ -340,14 +340,14 @@
         <div class="r-unit"  id="res-via-note">from dead counts</div>
       </div>
       <div class="result-box hl-blue">
-        <div class="r-label">Final Density</div>
+        <div class="r-label">Final Concentration</div>
         <div class="r-value" id="res-density">—</div>
-        <div class="r-unit"  id="res-density-note">cells / mL</div>
+        <div class="r-unit"  id="res-density-note">cells/mL</div>
       </div>
       <div class="result-box hl-blue">
         <div class="r-label" id="res-total-label">Total Live Cells</div>
         <div class="r-value" id="res-total">—</div>
-        <div class="r-unit"  id="res-total-note">density × vol</div>
+        <div class="r-unit"  id="res-total-note">conc. × vol</div>
       </div>
     </div>
 
@@ -679,7 +679,7 @@ function calcStep1() {
     document.getElementById('via-note').className        = 'via-note';
     document.getElementById('res-total-label').textContent = 'Total Cells';
     document.getElementById('res-density').textContent      = fmt(step1FinalDensity);
-    document.getElementById('res-density-note').textContent = !isNaN(step1FinalDensity) ? 'cells / mL (entered)' : 'cells / mL';
+    document.getElementById('res-density-note').textContent = !isNaN(step1FinalDensity) ? 'cells/mL (entered)' : 'cells/mL';
     document.getElementById('res-total').textContent        = '—';
     document.getElementById('res-total-note').textContent   = '—';
     document.getElementById('btn-next').disabled = isNaN(step1FinalDensity);
@@ -759,10 +759,10 @@ function calcStep1() {
 
   // density + total
   document.getElementById('res-density').textContent      = fmt(finalDensity);
-  document.getElementById('res-density-note').textContent = !isNaN(avgLive) ? mode.formulaNote : 'cells / mL';
+  document.getElementById('res-density-note').textContent = 'cells/mL';
   document.getElementById('res-total').textContent        = fmt(totalCells);
   document.getElementById('res-total-note').textContent   =
-    !isNaN(finalDensity) && !isNaN(vol) && vol > 0 ? `density × ${vol} mL`
+    !isNaN(finalDensity) && !isNaN(vol) && vol > 0 ? `conc. × ${vol} mL`
     : !isNaN(finalDensity) ? 'enter resuspension vol' : '—';
 
   // enable Next button only when we have a valid density
@@ -961,7 +961,7 @@ function calcDilution() {
 
   // C1 is always locked — it should never be empty
   if (emptyFields.includes('c1')) {
-    showDilError('C₁ is inherited from Step 1 — go back if the density needs updating.');
+    showDilError('C₁ is inherited from Step 1 — go back if the concentration needs updating.');
     ansBox.classList.add('hidden');
     mediaNote.classList.add('hidden');
     return;
@@ -1161,7 +1161,7 @@ function getCellCountRows() {
       ['=== Cell Count ===', ''],
       ['Mode',                            'Bypass — concentration entered directly'],
       ['Known concentration (cells/mL)',  document.getElementById('bypass-conc').value || ''],
-      ['Final density (cells/mL)',        document.getElementById('res-density').textContent],
+      ['Final concentration (cells/mL)', document.getElementById('res-density').textContent],
     ];
   }
   const mode  = MODES.find(m => m.id === currentModeId);
@@ -1179,7 +1179,7 @@ function getCellCountRows() {
     ['Resuspension volume (mL)',          document.getElementById('vol').value  || ''],
     ['Average live count',               document.getElementById('res-avg').textContent],
     ['Viability',                         document.getElementById('res-via').textContent],
-    ['Final density (cells/mL)',          document.getElementById('res-density').textContent],
+    ['Final concentration (cells/mL)',    document.getElementById('res-density').textContent],
     ['Total cells',                       document.getElementById('res-total').textContent],
   ];
 }


### PR DESCRIPTION
## Summary

- Add **unit legend** (K / M / B) after the Step 1 results grid — matches the existing legend in `cell-count`
- Fix **count-all `via-note`** message: `'Dead cell counting disabled.'` → `'Dead cell counting disabled — all cells counted as live.'`
- Add `container.innerHTML = ''` to `buildModeSelector()` to prevent duplicate mode-option elements if the function is ever called more than once

## Context

`seeding-calc` embeds a copy of the cell-count Step 1 logic with an explicit `⟳ SYNC SECTION` marker. These three gaps were found during a line-by-line comparison after the `fix/concentration-label` label rename. All other logic (formulas, viability conditions, negative-count guard, Final Concentration label, cells/mL unit) was already in sync.

## Test plan

- [ ] Open `tools/seeding-calc/index.html` in browser; confirm unit legend appears below Step 1 results
- [ ] Toggle "Count all cells" — `via-note` should read `"Dead cell counting disabled — all cells counted as live."`
- [ ] DevTools console: call `buildModeSelector()` a second time — mode options must not duplicate
- [ ] Navigate to Step 2, solve for V₁ — end-to-end still works
- [ ] Confirm `tools/cell-count/index.html` behavior matches on both points above

🤖 Generated with [Claude Code](https://claude.com/claude-code)